### PR TITLE
Change to using GLCore

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -533,7 +533,7 @@ PlayerSettings:
     m_APIs: 0b00000015000000
     m_Automatic: 0
   - m_BuildTarget: LinuxStandaloneSupport
-    m_APIs: 1500000011000000
+    m_APIs: 1100000015000000
     m_Automatic: 0
   - m_BuildTarget: WindowsStandaloneSupport
     m_APIs: 02000000120000001500000011000000


### PR DESCRIPTION
Changes Linux Builds to use GLCore as Vulkan is crashing on my system.

Note: I have no idea if this only crashes on nVidia's drivers or not.