### PR TITLE
Use AudioSource for VLC Players

### DIFF
--- a/Assets/Scripts/Game/Video/VLCVideoPlayer.cs
+++ b/Assets/Scripts/Game/Video/VLCVideoPlayer.cs
@@ -54,13 +54,11 @@ namespace Hypernex.Game.Video
 	            if (screen.material == null)
 		            screen.material = new Material(Shader.Find("Universal Render Pipeline/Lit"));
             }
-            AudioSource audioSource = descriptor.AudioOutput;
-            if (audioSource == null) audioSource = attachedObject.GetComponent<AudioSource>();
-            if (audioSource == null) audioSource = attachedObject.AddComponent<AudioSource>();
+            if (descriptor.AudioOutput == null) descriptor.AudioOutput = attachedObject.GetComponent<AudioSource>();
+            if (descriptor.AudioOutput == null) descriptor.AudioOutput = attachedObject.AddComponent<AudioSource>();
             if (libVLC == null)
 	            CreateLibVLC();
-            vlcAudioSource = audioSource.gameObject.AddComponent<VLCAudioSource>();
-	        vlcAudioSource.Create(CreateMediaPlayer());
+            CreateMediaPlayer();
             descriptor.CurrentVideoPlayer = this;
         }
 
@@ -155,6 +153,15 @@ namespace Hypernex.Game.Video
 	        }
         }
 
+        private void CreateAudio()
+        {
+	        if(vlcAudioSource != null) return;
+	        vlcAudioSource = videoPlayerDescriptor.AudioOutput.gameObject.GetComponent<VLCAudioSource>();
+	        if(vlcAudioSource == null)
+				vlcAudioSource = videoPlayerDescriptor.AudioOutput.gameObject.AddComponent<VLCAudioSource>();
+	        vlcAudioSource.Create(mediaPlayer);
+        }
+
         public override void Update()
         {
             uint height = 0;
@@ -208,7 +215,11 @@ namespace Hypernex.Game.Video
 	        }
         }
 
-        public async void Play() => await mediaPlayer.PlayAsync();
+        public async void Play()
+        {
+	        CreateAudio();
+	        await mediaPlayer.PlayAsync();
+        }
 
         public async void Pause() => await mediaPlayer.PauseAsync();
 
@@ -281,6 +292,8 @@ namespace Hypernex.Game.Video
 			}
 			mediaPlayer.Dispose();
 			mediaPlayer = null;
+			if(vlcAudioSource != null)
+				Object.Destroy(vlcAudioSource);
 		}
 
 		private void DestroyRenderTexture()

--- a/Assets/Scripts/Game/Video/VideoPlayerManager.cs
+++ b/Assets/Scripts/Game/Video/VideoPlayerManager.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using Hypernex.CCK.Unity;
-using UnityEngine;
 
 namespace Hypernex.Game.Video
 {
@@ -48,6 +47,8 @@ namespace Hypernex.Game.Video
             return DefaultVideoPlayerType;
         }
 #nullable restore
+
+        public static bool IsRegistered(Type videoPlayerType) => videoPlayerTypes.ContainsKey(videoPlayerType);
 
         public static bool IsStream(Uri uri)
         {

--- a/Assets/Scripts/Sandboxing/SandboxedTypes/Streaming.cs
+++ b/Assets/Scripts/Sandboxing/SandboxedTypes/Streaming.cs
@@ -60,14 +60,19 @@ namespace Hypernex.Sandboxing.SandboxedTypes
                         new StreamDownload(url, true));
                     return;
                 }
-                OptionSet optionSet = new OptionSet
-                {
+                OptionSet optionSet;
+                // TODO: (Somehow?) check if the video player uses VLC
+                if (VideoPlayerManager.IsRegistered(typeof(VLCVideoPlayer)))
+                    optionSet = new OptionSet();
+                else
+                    optionSet = new OptionSet
+                    {
 #if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN || UNITY_MAC
-                    Format = "bestvideo[vcodec=vp8]/bestvideo[vcodec=h264]+bestaudio/best"
+                        Format = "bestvideo[vcodec=vp8]/bestvideo[vcodec=h264]+bestaudio/best"
 #else
-                    Format = "bestvideo[vcodec=vp8]+bestaudio/best"
+                        Format = "bestvideo[vcodec=vp8]+bestaudio/best"
 #endif
-                };
+                    };
                 RunResult<string> runResult;
                 runResult = options.AudioOnly
                     ? await ytdl.RunAudioDownload(url, overrideOptions: optionSet)


### PR DESCRIPTION
This draft introduces VLC Video Player outputting to Unity's AudioSources. This is currently a draft because there are many missing features and plenty of bugs.

## Issues

1. Only 1 channel is supported.
2. Audio is delayed with some media.
    - It is unknown if frame stutters has to do with this
    - There should still be some sort of check to sync audio back to video
3. Hypernex dependent code
    - While this isn't an issue for Hypernex, this code will be used towards contributions to other projects. For this reason, any Hypernex dependencies should be removed.
    - Currently using QuickInvoke

## Checklist

- [X] Output Audio from VLC to AudioSource
- [ ] Channels
    - [X] 1 Channel
    - [X] 2 Channels
    - [ ] Other Channels
- [X] Frequencies
    - Currently set to `48000`, but can be adjusted
- [X] Synchronous Audio
  + Still a WIP but much better now

## Demo

https://github.com/user-attachments/assets/5e8c7bc7-f592-4983-88a7-aed19d24d9f5