### PR TITLE
[#86] Lagging Out of an Instance Breaks Client

### DIFF
--- a/Assets/Scripts/Game/LocalPlayer.cs
+++ b/Assets/Scripts/Game/LocalPlayer.cs
@@ -384,8 +384,6 @@ namespace Hypernex.Game
             APIPlayer.APIObject.GetAvatarMeta(OnAvatarMeta, ConfigManager.SelectedConfigUser.CurrentAvatar);
         }
 
-        private List<Coroutine> lastCoroutine = new();
-
         private void Start()
         {
             if (Instance != null)
@@ -395,7 +393,7 @@ namespace Hypernex.Game
                 return;
             }
             Instance = this;
-            LocalPlayerSyncController = new LocalPlayerSyncController(this, i => lastCoroutine.Add(StartCoroutine(i)));
+            LocalPlayerSyncController = new LocalPlayerSyncController(this, i => StartCoroutine(i));
             APIPlayer.OnUser += _ => LoadAvatar();
             CharacterController.minMoveDistance = 0;
             LockCamera = Dashboard.IsVisible;
@@ -449,10 +447,6 @@ namespace Hypernex.Game
                 {
                     if (avatarMeta.Publicity == AvatarPublicity.OwnerOnly)
                         ShareAvatarTokenToUserId(user, avatarMeta);
-                };
-                instance.OnDisconnect += () =>
-                {
-                    lastCoroutine.ForEach(StopCoroutine);
                 };
                 if (avatarMeta == null) return;
                 if (avatarMeta.Publicity == AvatarPublicity.OwnerOnly)
@@ -807,7 +801,6 @@ namespace Hypernex.Game
                 if(binding.GetType() == typeof(Bindings.Mouse))
                     ((Bindings.Mouse)binding).Dispose();
             }
-            lastCoroutine.ForEach(StopCoroutine);
             denoiser?.Dispose();
             LocalPlayerSyncController?.Dispose();
         }

--- a/Assets/Scripts/Tools/Debug/InstanceDebug.cs
+++ b/Assets/Scripts/Tools/Debug/InstanceDebug.cs
@@ -1,0 +1,25 @@
+﻿using Hypernex.Game;
+using UnityEngine;
+
+namespace Hypernex.Tools.Debug
+{
+    [RequireComponent(typeof(DontDestroyMe))]
+    public class InstanceDebug : MonoBehaviour
+    {
+        private void OnGUI()
+        {
+            GUILayout.Label("Number of Instances: " + GameInstance.GameInstances.Length);
+            GameInstance gameInstance = GameInstance.FocusedInstance;
+            if (gameInstance == null)
+            {
+                GUILayout.Label("Not connected!");
+                return;
+            }
+            GUILayout.Label("Is Open: " + gameInstance.IsOpen);
+            GUILayout.Label("Game Server: " + gameInstance.gameServerId);
+            GUILayout.Label("Instance: " + gameInstance.instanceId);
+            GUILayout.Label("Is Host: " + gameInstance.isHost);
+            GUILayout.Label("Is Authed: " + gameInstance.authed);
+        }
+    }
+}

--- a/Assets/Scripts/Tools/Debug/InstanceDebug.cs.meta
+++ b/Assets/Scripts/Tools/Debug/InstanceDebug.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 070fd269a5844c28bcfc73b75cd32df1
+timeCreated: 1731424769

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -5,7 +5,7 @@
     "com.unity.burst": "1.8.17",
     "com.unity.collab-proxy": "2.3.1",
     "com.unity.entities": "1.0.16",
-    "com.unity.ide.rider": "3.0.31",
+    "com.unity.ide.rider": "3.0.34",
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.mobile.android-logcat": "1.4.2",
     "com.unity.physics": "1.0.16",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -71,7 +71,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.31",
+      "version": "3.0.34",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
This PR fixes the issue where a client will not send messages after an unexpected disconnect. This may happen when the client freezes (such as VLC loading), a user is kicked, or a user is banned from an instance.