### PR TITLE
Add Animator Sandbox APIs

### DIFF
--- a/Assets/Scripts/Sandboxing/SandboxForwarding.cs
+++ b/Assets/Scripts/Sandboxing/SandboxForwarding.cs
@@ -46,6 +46,7 @@ namespace Hypernex.Sandboxing
             ["ScriptEvents"] = typeof(ScriptEvents),
             ["ScriptEvent"] = typeof(ScriptEvent),
             ["Interactables"] = typeof(Interactables),
+            ["Animator"] = typeof(SandboxedTypes.Components.Animator),
             ["Audio"] = typeof(Audio),
             ["Video"] = typeof(Video),
             ["Button"] = typeof(Button),

--- a/Assets/Scripts/Sandboxing/SandboxedTypes/Components/Animator.cs
+++ b/Assets/Scripts/Sandboxing/SandboxedTypes/Components/Animator.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections;
+using System.IO;
+using Hypernex.Game;
+using Hypernex.Tools;
+using Nexbox;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace Hypernex.Sandboxing.SandboxedTypes.Components
+{
+    public class Animator
+    {
+        private readonly Item item;
+        private readonly bool read;
+        private UnityEngine.Animator animator;
+        
+        private static UnityEngine.Animator GetAnimator(Item item)
+        {
+            UnityEngine.Animator a = item.t.GetComponent<UnityEngine.Animator>();
+            if (a == null)
+                return null;
+            return a;
+        }
+
+        public Animator(Item i)
+        {
+            item = i;
+            read = i.IsReadOnly;
+            animator = GetAnimator(i);
+            if (animator == null) throw new Exception("No Animator found on Item at " + i.Path);
+        }
+
+        public bool IsValid() => animator != null;
+
+        public bool IsStateName(int layer, string name) => animator.GetCurrentAnimatorStateInfo(layer).IsName(name);
+        public bool IsStateTag(int layer, string name) => animator.GetCurrentAnimatorStateInfo(layer).IsTag(name);
+
+        public bool GetBool(string name) => animator.GetBool(name);
+        public float GetFloat(string name) => animator.GetFloat(name);
+        public int GetInt(string name) => animator.GetInteger(name);
+
+        public void SetTrigger(string name)
+        {
+            if (read)
+                return;
+            animator.SetTrigger(name);
+        }
+        public void SetBool(string name, bool value)
+        {
+            if (read)
+                return;
+            animator.SetBool(name, value);
+        }
+        public void SetFloat(string name, float value)
+        {
+            if (read)
+                return;
+            animator.SetFloat(name, value);
+        }
+        public void SetInt(string name, int value)
+        {
+            if (read)
+                return;
+            animator.SetInteger(name, value);
+        }
+    }
+}

--- a/Assets/Scripts/Sandboxing/SandboxedTypes/Components/Animator.cs.meta
+++ b/Assets/Scripts/Sandboxing/SandboxedTypes/Components/Animator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cacf85ad954b757dbb3169f934d3cb18

--- a/Assets/Scripts/Sandboxing/SandboxedTypes/Item.cs
+++ b/Assets/Scripts/Sandboxing/SandboxedTypes/Item.cs
@@ -264,6 +264,7 @@ namespace Hypernex.Sandboxing.SandboxedTypes
         private static readonly IReadOnlyDictionary<string, Type> ComponentTypes = new ReadOnlyDictionary<string, Type>(
             new Dictionary<string, Type>
             {
+                ["animator"] = typeof(Components.Animator),
                 ["audio"] = typeof(Audio),
                 ["button"] = typeof(Button),
                 ["dropdown"] = typeof(Dropdown),


### PR DESCRIPTION
Adds the following APIs to scripting:
- `Animator` Component
- `IsValid`
- `IsStateName`
- `IsStateTag`
- `GetBool`
- `GetFloat`
- `GetInt`
- `SetTrigger` (must be not-reaonly)
- `SetBool` (must be not-reaonly)
- `SetFloat` (must be not-reaonly)
- `SetInt` (must be not-reaonly)