### PR TITLE
Fix Microphone Delay

### DIFF
--- a/Assets/Scripts/Game/Audio/BufferAudioSource.cs
+++ b/Assets/Scripts/Game/Audio/BufferAudioSource.cs
@@ -31,6 +31,8 @@ namespace Hypernex.Game.Audio
         private int AudioThreadPosition = 0;
         private int MainThreadPosition = 0;
 
+        private int targetBufferSamples;
+        private int maxBufferSamples;
         private Queue<float> queue = new Queue<float>();
         private AudioPacket[] buffer = new AudioPacket[1024];
         private bool startedQueue = false;
@@ -281,6 +283,10 @@ namespace Hypernex.Game.Audio
                 {
                     queue.Enqueue(val);
                 }
+                while (queue.Count > maxBufferSamples)
+                {
+                    queue.Dequeue();
+                }
                 mutex.ReleaseMutex();
             }
             else
@@ -299,6 +305,8 @@ namespace Hypernex.Game.Audio
                 // Debug.Log("new clip");
                 startedQueue = false;
                 shouldStop = false;
+                targetBufferSamples = (int)(frequency * channels * 0.05f);
+                maxBufferSamples = targetBufferSamples * 2;
                 clip = AudioClip.Create("Voice", CLIP_SAMPLE_SIZE, channels, frequency, false);
                 float[] temp = new float[CLIP_SAMPLE_SIZE];
                 Array.Fill(temp, 1f);


### PR DESCRIPTION
Currently, whenever a microphone is left on for too long, the voice chat will start to delay over time, causing what should be low-latency voice chat, be extremely high latency. This issue was detected when redoing visemes in another branch, where I noticed the visemes would be on time with the voice chat, but the audio was delayed, which indicated to me that the issue was on the client decoding the packets, not on the game server relaying them.

After some digging, I realized the source issue was in the BufferAudioSource component, specifically the AddQueue function. What happens whenever PCM Buffers are enqueued, they will continue to stack without limitation. Simply setting a limitation (maxBufferSamples) and clearing the queue (dequeue) whenever the current queue exceeds the limit fixes this without issue (tested in Editor).